### PR TITLE
[VT2-262] 거래내역 없을 경우 시세통계 0으로 저장

### DIFF
--- a/src/main/java/eureca/capstone/project/batch/component/tasklet/TransactionStatisticSaveTasklet.java
+++ b/src/main/java/eureca/capstone/project/batch/component/tasklet/TransactionStatisticSaveTasklet.java
@@ -1,0 +1,104 @@
+package eureca.capstone.project.batch.component.tasklet;
+
+import eureca.capstone.project.batch.common.entity.TelecomCompany;
+import eureca.capstone.project.batch.common.repository.TelecomCompanyRepository;
+import eureca.capstone.project.batch.component.writer.TransactionStatisticWriter;
+import eureca.capstone.project.batch.dto.StatisticResponseDto;
+import eureca.capstone.project.batch.market_statistic.domain.MarketStatistic;
+import eureca.capstone.project.batch.market_statistic.domain.TransactionAmountStatistic;
+import eureca.capstone.project.batch.market_statistic.repository.MarketStatisticRepository;
+import eureca.capstone.project.batch.market_statistic.repository.TransactionAmountStatisticRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.StepContribution;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.core.scope.context.ChunkContext;
+import org.springframework.batch.core.step.tasklet.Tasklet;
+import org.springframework.batch.item.ExecutionContext;
+import org.springframework.batch.repeat.RepeatStatus;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+@Component
+@StepScope
+@RequiredArgsConstructor
+@Slf4j
+public class TransactionStatisticSaveTasklet implements Tasklet {
+    private static final int PRICE_PER_MB = 100; // 100MB 단위
+    private final TelecomCompanyRepository telecomCompanyRepository;
+    private final MarketStatisticRepository marketStatisticRepository;
+    private final TransactionAmountStatisticRepository transactionAmountStatisticRepository;
+
+    @Value("#{jobParameters['currentTime']}")
+    private String currentTimeStr;
+
+    @Override
+    public RepeatStatus execute(StepContribution contribution, ChunkContext chunkContext) throws Exception {
+        ExecutionContext executionContext = chunkContext.getStepContext().getStepExecution()
+                .getJobExecution().getExecutionContext();
+
+        LocalDateTime statisticsTime = LocalDateTime.parse(currentTimeStr)
+                .minusHours(1)
+                .withMinute(0)
+                .withSecond(0)
+                .withNano(0);
+
+        Map<Long, StatisticResponseDto> statistics =
+                (Map<Long, StatisticResponseDto>) executionContext.get(TransactionStatisticWriter.STEP_STATISTIC_KEY);
+
+        if (statistics == null) {
+            statistics = new HashMap<>();
+            log.info("[TransactionStatisticSaveTasklet execute] 거래내역 0건으로 누적통계 map 없음. 빈 map 생성");
+        }
+
+
+        // 3) 전체 통신사 조회 후 각각 저장 (없으면 0)
+        List<TelecomCompany> telecoms = telecomCompanyRepository.findAll();
+
+        if (telecoms.isEmpty()) {
+            throw new IllegalArgumentException("TelecomCompany Not Found");
+        }
+
+        List<MarketStatistic> marketStats = new ArrayList<>();
+        long totalCount = 0L;
+
+        for (TelecomCompany telecom : telecoms) {
+            StatisticResponseDto dto = statistics.getOrDefault(
+                    telecom.getTelecomCompanyId(),
+                    StatisticResponseDto.builder()
+                            .totalPrice(0L)
+                            .totalDataAmount(0L)
+                            .transactionCount(0L)
+                            .build());
+
+            Long avgPrice = dto.getTotalDataAmount() == 0 ? null : Math.round((double) dto.getTotalPrice() / dto.getTotalDataAmount() * PRICE_PER_MB);
+
+            marketStats.add(MarketStatistic.builder()
+                    .telecomCompany(telecom)
+                    .averagePrice(avgPrice)
+                    .transactionAmount(dto.getTransactionCount())
+                    .staticsTime(statisticsTime)
+                    .build());
+
+            totalCount += dto.getTransactionCount();
+        }
+
+        // 시세 통계 저장
+        marketStatisticRepository.saveAll(marketStats);
+
+        // 거래량 통계 저장
+        transactionAmountStatisticRepository.save(TransactionAmountStatistic.builder()
+                .transactionAmount(totalCount)
+                .staticsTime(statisticsTime)
+                .build());
+
+        log.info("[SaveTasklet] 저장 완료. time={}, marketStats={}, totalCnt={}", statisticsTime, marketStats.size(), totalCount);
+
+        return RepeatStatus.FINISHED;
+    }
+}

--- a/src/main/java/eureca/capstone/project/batch/component/writer/TransactionStatisticWriter.java
+++ b/src/main/java/eureca/capstone/project/batch/component/writer/TransactionStatisticWriter.java
@@ -2,6 +2,7 @@ package eureca.capstone.project.batch.component.writer;
 
 import eureca.capstone.project.batch.common.entity.TelecomCompany;
 import eureca.capstone.project.batch.common.repository.TelecomCompanyRepository;
+import eureca.capstone.project.batch.dto.StatisticResponseDto;
 import eureca.capstone.project.batch.market_statistic.domain.MarketStatistic;
 import eureca.capstone.project.batch.market_statistic.domain.TransactionAmountStatistic;
 import eureca.capstone.project.batch.market_statistic.repository.MarketStatisticRepository;
@@ -10,12 +11,16 @@ import eureca.capstone.project.batch.transaction_feed.domain.DataTransactionHist
 import eureca.capstone.project.batch.transaction_feed.domain.TransactionFeed;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.StepExecution;
+import org.springframework.batch.core.annotation.BeforeStep;
 import org.springframework.batch.core.configuration.annotation.StepScope;
 import org.springframework.batch.item.Chunk;
+import org.springframework.batch.item.ExecutionContext;
 import org.springframework.batch.item.ItemWriter;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
+import java.io.Serializable;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -27,134 +32,67 @@ import java.util.Map;
 @RequiredArgsConstructor
 @Slf4j
 public class TransactionStatisticWriter implements ItemWriter<DataTransactionHistory> {
-    private static final int PRICE_PER_MB = 100; // 100MB 단위
-    private final MarketStatisticRepository marketStatisticRepository;
-    private final TransactionAmountStatisticRepository transactionAmountStatisticRepository;
-    private final TelecomCompanyRepository telecomCompanyRepository;
+    public static final String STEP_STATISTIC_KEY = "telecomStatistic";
+    private StepExecution stepExecution;
+    private Map<Long, StatisticResponseDto> statistics; // (통신사 id,계산)
 
-    @Value("#{jobParameters['currentTime']}")
-    private String currentTimeStr;
-    private LocalDateTime statisticsTime;
-    private List<TelecomCompany> telecomCompanies;
+    @BeforeStep
+    public void saveStepExecution(StepExecution stepExecution) {
+        this.stepExecution = stepExecution;
+        ExecutionContext executionContext = stepExecution.getExecutionContext();
 
-    @Override
-    public void write(Chunk<? extends DataTransactionHistory> chunk) throws Exception {
+        this.statistics = (Map<Long, StatisticResponseDto>) executionContext.get(STEP_STATISTIC_KEY);
 
-        if (statisticsTime == null) {
-            statisticsTime = LocalDateTime.parse(currentTimeStr)
-                    .minusHours(1)
-                    .withMinute(0)
-                    .withSecond(0)
-                    .withNano(0);
-            log.info("통계 시간: {}", statisticsTime);
+        if (this.statistics == null) {
+            this.statistics = new HashMap<>();
+            executionContext.put(STEP_STATISTIC_KEY, this.statistics);
+            log.info("[saveStepExecution] 기존 누적 map 없음. 새 누적 map 생성.");
+        } else {
+            log.info("[saveStepExecution] 기존 누적 map 로드 (재시작)");
         }
-
-        if (telecomCompanies == null) {
-            telecomCompanies = telecomCompanyRepository.findAll();
-
-            if (telecomCompanies.isEmpty()) {
-                log.warn("[saveMarketStatistics] 등록된 통신사가 없습니다.");
-                return;
-            }
-        }
-
-        // 통신사별 통계
-        Map<TelecomCompany, StatisticCalculator> telecomStatistics = getTelecomStatistics(chunk.getItems());
-
-        // 시세 통계 저장
-        saveMarketStatistics(telecomStatistics);
-
-        // 거래량 통계 저장
-        saveTransactionAmountStatistics(telecomStatistics);
     }
 
-    private Map<TelecomCompany, StatisticCalculator> getTelecomStatistics(List<? extends DataTransactionHistory> items) {
-        Map<TelecomCompany, StatisticCalculator> telecomStatistics = new HashMap<>();
+    @Override
+    public void write(Chunk<? extends DataTransactionHistory> chunk) {
 
-        for (DataTransactionHistory history : items) {
-
+        for (DataTransactionHistory history : chunk.getItems()) {
             TransactionFeed feed = history.getTransactionFeed();
             if(feed == null){
-                log.warn("[getTelecomStatistics] {}번 거래내역의 TransactionFeed가 null입니다.", history.getTransactionHistoryId());
+                log.warn("[write] {}번 거래내역의 TransactionFeed가 null", history.getTransactionHistoryId());
                 continue;
             }
             TelecomCompany telecom = feed.getTelecomCompany();
             if(telecom == null){
-                log.warn("[getTelecomStatistics] {}번 거래내역의 TelecomCompany가 null입니다.", history.getTransactionHistoryId());
+                log.warn("[write] {}번 거래내역의 TelecomCompany가 null", history.getTransactionHistoryId());
                 continue;
             }
 
-            telecomStatistics.computeIfAbsent(telecom, k -> new StatisticCalculator())
-                    .addTransaction(history.getTransactionFinalPrice(), history.getTransactionFeed().getSalesDataAmount());
-            log.info("[통계 누적] 통신사: {}, price: {}, amount: {}", telecom.getName(), history.getTransactionFinalPrice(), feed.getSalesDataAmount());
+            Long telecomId = history.getTransactionFeed().getTelecomCompany().getTelecomCompanyId();
 
-        }
-        return telecomStatistics;
-    }
+            StatisticResponseDto statisticDto = statistics.getOrDefault(
+                    telecomId,
+                    StatisticResponseDto.builder()
+                        .totalPrice(0L)
+                        .totalDataAmount(0L)
+                        .transactionCount(0L)
+                        .build()
+            );
 
-    private void saveMarketStatistics(Map<TelecomCompany, StatisticCalculator> telecomStatistics) {
-        List<MarketStatistic> statistics = new ArrayList<>();
+            Long price = history.getTransactionFinalPrice() == null ? 0L : history.getTransactionFinalPrice();
+            Long dataAmount = history.getTransactionFeed().getSalesDataAmount() == null ? 0L : history.getTransactionFeed().getSalesDataAmount();
 
-        for(TelecomCompany telecom : telecomCompanies){
-            StatisticCalculator calc = telecomStatistics.getOrDefault(telecom, new StatisticCalculator());
-
-            MarketStatistic statistic = MarketStatistic.builder()
-                    .telecomCompany(telecom)
-                    .averagePrice(calc.getAveragePrice())
-                    .transactionAmount(calc.getTransactionAmount())
-                    .staticsTime(statisticsTime)
+            statisticDto = StatisticResponseDto.builder()
+                    .totalPrice(statisticDto.getTotalPrice() + price)
+                    .totalDataAmount(statisticDto.getTotalDataAmount() + dataAmount)
+                    .transactionCount(statisticDto.getTransactionCount() + 1)
                     .build();
 
-            statistics.add(statistic);
-            log.info("[saveMarketStatistics] 시세통계 time: {}. 통신사: {}", statisticsTime, statistic.getTelecomCompany().getName());
+            log.info("[write] 통신사: {}, price: {}, amount: {}", telecom.getName(), history.getTransactionFinalPrice(), feed.getSalesDataAmount());
+
+            statistics.put(telecomId, statisticDto);
         }
 
-        marketStatisticRepository.saveAll(statistics);
-        log.info("[saveMarketStatistics] 시세통계 db 저장 완료: {}건. time: {}", statistics.size(), statisticsTime);
-    }
-
-    private void saveTransactionAmountStatistics(Map<TelecomCompany, StatisticCalculator> telecomStatistics) {
-
-        long amount = 0L;
-        for(StatisticCalculator calc : telecomStatistics.values()){
-            amount += calc.getTransactionAmount();
-        }
-
-        TransactionAmountStatistic totalAmount = TransactionAmountStatistic.builder()
-                .transactionAmount(amount)
-                .staticsTime(statisticsTime)
-                .build();
-
-        transactionAmountStatisticRepository.save(totalAmount);
-        log.info("[saveTransactionAmountStatistics] 거래량 통계 db 저장 완료. time: {}", statisticsTime);
-    }
-
-
-
-    // 시세 / 거래량 통계 계산용 내부 클래스
-    private static class StatisticCalculator {
-        private long totalPrice = 0;
-        private long transactionCount = 0;
-        private long totalDataAmount = 0;
-
-        public void addTransaction(Long price, Long dataAmount) {
-            if (price != null) {
-                this.totalPrice += price;
-                this.transactionCount++;
-            }
-            if (dataAmount != null) {
-                this.totalDataAmount += dataAmount;
-            }
-        }
-
-        public long getAveragePrice() {
-            if(totalPrice == 0) return 0;
-            double avg = (double) totalPrice / totalDataAmount * PRICE_PER_MB;
-            return Math.round(avg);
-        }
-
-        public long getTransactionAmount() {
-            return transactionCount;
-        }
+        stepExecution.getExecutionContext().put(STEP_STATISTIC_KEY, statistics);
+        log.info("[write] 누적 집계 완료. 거래내역: {}건, 실 집계: {}개 통신사", chunk.getItems().size(), statistics.size());
     }
 }

--- a/src/main/java/eureca/capstone/project/batch/config/TransactionStatisticJobConfig.java
+++ b/src/main/java/eureca/capstone/project/batch/config/TransactionStatisticJobConfig.java
@@ -1,6 +1,7 @@
 package eureca.capstone.project.batch.config;
 
 import eureca.capstone.project.batch.component.listener.ExecutionListener;
+import eureca.capstone.project.batch.component.retry.RetryPolicy;
 import eureca.capstone.project.batch.component.tasklet.TransactionStatisticSaveTasklet;
 import eureca.capstone.project.batch.component.writer.TransactionStatisticWriter;
 import eureca.capstone.project.batch.transaction_feed.domain.DataTransactionHistory;
@@ -40,7 +41,7 @@ public class TransactionStatisticJobConfig {
     private final JobRepository jobRepository;
     private final PlatformTransactionManager platformTransactionManager;
     private final EntityManagerFactory entityManagerFactory;
-    private final DataSource dataSource;
+    private final RetryPolicy retryPolicy;
     private final ExecutionListener executionListener;
     private final TransactionStatisticWriter transactionStatisticWriter;
     private final TransactionStatisticSaveTasklet transactionStatisticSaveTasklet;
@@ -60,8 +61,8 @@ public class TransactionStatisticJobConfig {
                 .reader(transactionHistoryJpaReader(null))
                 .writer(transactionStatisticWriter)
                 .faultTolerant()
-                .retryPolicy(retryPolicyStatistic())
-                .backOffPolicy(fixedBackOffPolicyStatistic())
+                .retryPolicy(retryPolicy.createRetryPolicy())
+                .backOffPolicy(retryPolicy.createBackoffPolicy())
                 .listener(executionListener)
                 .listener(promotionListener())
                 .build();

--- a/src/main/java/eureca/capstone/project/batch/controller/BatchController.java
+++ b/src/main/java/eureca/capstone/project/batch/controller/BatchController.java
@@ -62,7 +62,7 @@ public class BatchController {
         }
     }
 
-    @Operation(summary = "거래량/시세 통계 배치 수동 실행", description = "매 시간마다 이전시간의 거래량과 통신사별 시세 통계를 내리는 배치를 수동으로 즉시 실행합니다.")
+    @Operation(summary = "거래량/시세 통계 배치 수동 실행", description = "매 시간마다 이전시간의 거래량과 통신사별 시세 통계를 내리는 배치를 수동으로 즉시 실행합니다.(거래내역 없을 경우 시세: null, 거래량: 0 으로 저장)")
     @PostMapping("/statistic-transaction")
     public String runStatisticBatchManual() {
         try {

--- a/src/main/java/eureca/capstone/project/batch/dto/StatisticResponseDto.java
+++ b/src/main/java/eureca/capstone/project/batch/dto/StatisticResponseDto.java
@@ -1,0 +1,22 @@
+package eureca.capstone.project.batch.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.io.Serial;
+import java.io.Serializable;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class StatisticResponseDto implements Serializable {
+    @Serial
+    private static final long serialVersionUID = 1L;
+
+    private Long totalPrice;
+    private Long transactionCount;
+    private Long totalDataAmount;
+}

--- a/src/main/java/eureca/capstone/project/batch/market_statistic/domain/MarketStatistic.java
+++ b/src/main/java/eureca/capstone/project/batch/market_statistic/domain/MarketStatistic.java
@@ -23,10 +23,10 @@ public class MarketStatistic extends BaseEntity {
     private Long statisticsId;
 
     @Column(name = "average_price")
-    private long averagePrice;
+    private Long averagePrice;
 
     @Column(name = "transaction_amount")
-    private long transactionAmount;
+    private Long transactionAmount;
 
     @Column(name = "statics_time")
     private LocalDateTime staticsTime;

--- a/src/main/java/eureca/capstone/project/batch/schedule/ExpireDataCouponScheduler.java
+++ b/src/main/java/eureca/capstone/project/batch/schedule/ExpireDataCouponScheduler.java
@@ -8,7 +8,6 @@ import org.springframework.batch.core.launch.JobLauncher;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 @Component


### PR DESCRIPTION
## 주요 변경사항
- 거래내역이 없을 경우에도 통계를 저장하기 위해 2 Step으로 분리, Step간 데이터 전달은 ExecutionContexts로 
    - Step 1: chunk 기반 - 거래내역 조회 및 통계 누적 담당
    - Step 2: tasklet - 누적값 기반으로 통계 계산 및 db 저장 담당

* 거래내역이 없을 경우 평균가격은 null, 거래량은 0으로 저장됨