### PR TITLE
Feat/거래량 일반 입찰 구분

### DIFF
--- a/src/main/java/eureca/capstone/project/batch/common/controller/BatchController.java
+++ b/src/main/java/eureca/capstone/project/batch/common/controller/BatchController.java
@@ -32,7 +32,8 @@ public class BatchController {
 
     // Job Beans
     private final Job resetUserDataJob;
-    private final Job transactionStatisticJob;
+    private final Job normalStatisticJob;
+    private final Job bidStatisticJob;
     private final Job restrictionReleaseJob;
     private final Job expireGeneralSaleFeedJob;
     private final Job auctionProcessingJob;
@@ -59,20 +60,37 @@ public class BatchController {
         }
     }
 
-    @Operation(summary = "거래량/시세 통계 배치 수동 실행", description = "매 시간마다 이전시간의 거래량과 통신사별 시세 통계를 내리는 배치를 수동으로 즉시 실행합니다.(거래내역 없을 경우 시세: null, 거래량: 0 으로 저장)")
-    @PostMapping("/statistic-transaction")
-    public String runStatisticBatchManual() {
+    @Operation(summary = "일반판매 거래량/시세 통계 배치 수동 실행", description = "매 시간마다 이전시간의 일반판매 거래량과 통신사별 시세 통계를 내리는 배치를 수동으로 즉시 실행합니다.(거래내역 없을 경우 시세: null, 거래량: 0 으로 저장)")
+    @PostMapping("/statistic-normal-transaction")
+    public String runNormalBatchManual() {
         try {
-            log.info("[runStatisticBatchManual] 거래량/시세 통계 배치 수동 실행");
-            jobLauncher.run(transactionStatisticJob, new JobParametersBuilder()
+            log.info("[runNormalBatchManual] 일반판매 거래량/시세 통계 배치 실행");
+            jobLauncher.run(normalStatisticJob, new JobParametersBuilder()
                     .addLong("time", System.currentTimeMillis())
                     .addString("currentTime", LocalDateTime.now().toString())
                     .toJobParameters());
-            log.info("[runStatisticBatchManual] 거래량/시세 통계 배치 수동 실행 완료");
-            return "거래량/시세 통계 배치 수동 실행 완료";
+            log.info("[runNormalBatchManual] 일반판매 거래량/시세 통계 배치 실행 완료");
+            return "일반판매 거래량/시세 통계 배치 수동 실행 완료";
         } catch (Exception e) {
-            log.error("[runStatisticBatchManual] 거래량/시세 통계 배치 수동 실행 실패", e);
-            return "거래량/시세 통계 배치 수동 실행 실패: " + e.getMessage();
+            log.error("[runNormalBatchManual] 일반판매 거래량/시세 통계 배치 실행 실패", e);
+            return "일반판매 거래량/시세 통계 배치 수동 실행 실패: " + e.getMessage();
+        }
+    }
+
+    @Operation(summary = "입찰판매 거래량 통계 배치 수동 실행", description = "매일 자정에 전날의 입찰판매 거래량 통계를 내리는 배치를 수동으로 즉시 실행합니다.(거래내역 없을 경우 거래량: 0 으로 저장)")
+    @PostMapping("/statistic-bid-transaction")
+    public String runBidBatchManual() {
+        try {
+            log.info("[runBidBatchManual] 입찰판매 거래량 통계 배치 실행");
+            jobLauncher.run(bidStatisticJob, new JobParametersBuilder()
+                    .addLong("time", System.currentTimeMillis())
+                    .addString("currentTime", LocalDateTime.now().toString())
+                    .toJobParameters());
+            log.info("[runBidBatchManual] 입찰판매 거래량 통계 배치 실행 완료");
+            return "입찰판매 거래량 통계 배치 실행 완료";
+        } catch (Exception e) {
+            log.error("[runBidBatchManual] 입찰판매 거래량 통계 배치 실행 실패", e);
+            return "입찰판매 거래량 통계 배치 실행 실패: " + e.getMessage();
         }
     }
 

--- a/src/main/java/eureca/capstone/project/batch/common/schedule/TransactionStatisticScheduler.java
+++ b/src/main/java/eureca/capstone/project/batch/common/schedule/TransactionStatisticScheduler.java
@@ -7,9 +7,7 @@ import org.springframework.batch.core.JobParametersBuilder;
 import org.springframework.batch.core.launch.JobLauncher;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
-import org.springframework.web.bind.annotation.PostMapping;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 @Component
@@ -18,20 +16,39 @@ import java.time.LocalDateTime;
 public class TransactionStatisticScheduler {
 
     private final JobLauncher jobLauncher;
-    private final Job transactionStatisticJob;
+    private final Job normalStatisticJob;
+    private final Job bidStatisticJob;
 
+    // 시세통계 + 일반판매 거래량 통계
     @Scheduled(cron = "0 0 * * * *", zone = "Asia/Seoul")
-    public void runStatisticBatch() {
+    public void runNormalStatisticBatch() {
         try {
-            log.info("[runStatisticBatch] 거래량/시세 통계 배치 실행");
-            jobLauncher.run(transactionStatisticJob, new JobParametersBuilder()
+            log.info("[runStatisticBatch] 일반판매 거래량/시세 통계 배치 실행");
+            jobLauncher.run(normalStatisticJob, new JobParametersBuilder()
                     .addLong("time", System.currentTimeMillis())
                     .addString("currentTime", LocalDateTime.now().toString())
                     .toJobParameters());
-            log.info("[runStatisticBatch] 거래량/시세 통계 배치 실행 완료");
+            log.info("[runStatisticBatch] 일반판매 거래량/시세 통계 배치 실행 완료");
         } catch (Exception e) {
-            log.error("[runStatisticBatch] 거래량/시세 통계 배치 실행 실패", e);
+            log.error("[runStatisticBatch] 일반판매 거래량/시세 통계 배치 실행 실패", e);
+        }
+    }
+
+
+    // 같은 db에 접근하므로 입찰판매는 00:05분에 스케줄링
+    @Scheduled(cron = "0 5 0 * * *", zone = "Asia/Seoul")
+    private void runBidStatisticBatch() {
+        try {
+            log.info("[runBidStatisticBatch] 입찰판매 거래량 통계 배치 실행");
+            jobLauncher.run(bidStatisticJob, new JobParametersBuilder()
+                    .addLong("time", System.currentTimeMillis())
+                    .addString("currentTime", LocalDateTime.now().toString())
+                    .toJobParameters());
+            log.info("[runBidStatisticBatch] 입찰판매 거래량 통계 배치 실행 완료");
+        } catch (Exception e) {
+            log.error("[runBidStatisticBatch] 입찰판매 거래량 통계 배치 실행 실패: ", e);
         }
     }
 }
+
 

--- a/src/main/java/eureca/capstone/project/batch/component/tasklet/BidStatisticSaveTasklet.java
+++ b/src/main/java/eureca/capstone/project/batch/component/tasklet/BidStatisticSaveTasklet.java
@@ -1,0 +1,71 @@
+package eureca.capstone.project.batch.component.tasklet;
+
+import eureca.capstone.project.batch.component.writer.BidVolumeStatisticWriter;
+import eureca.capstone.project.batch.market_statistic.domain.TransactionAmountStatistic;
+import eureca.capstone.project.batch.market_statistic.repository.TransactionAmountStatisticRepository;
+import eureca.capstone.project.batch.transaction_feed.entity.SalesType;
+import eureca.capstone.project.batch.transaction_feed.repository.SalesTypeRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.StepContribution;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.core.scope.context.ChunkContext;
+import org.springframework.batch.core.step.tasklet.Tasklet;
+import org.springframework.batch.item.ExecutionContext;
+import org.springframework.batch.repeat.RepeatStatus;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+
+@Component
+@StepScope
+@RequiredArgsConstructor
+@Slf4j
+public class BidStatisticSaveTasklet implements Tasklet {
+    private final TransactionAmountStatisticRepository transactionAmountStatisticRepository;
+    private final SalesTypeRepository salesTypeRepository;
+
+    @Value("#{jobParameters['currentTime']}")
+    private String currentTimeStr;
+
+    @Override
+    public RepeatStatus execute(StepContribution contribution, ChunkContext chunkContext) throws Exception {
+        ExecutionContext executionContext = chunkContext.getStepContext().getStepExecution()
+                .getJobExecution().getExecutionContext();
+
+        LocalDateTime statisticsTime = LocalDateTime.parse(currentTimeStr)
+                .minusHours(1)
+                .truncatedTo(ChronoUnit.HOURS);
+
+        Long totalVolumeCount = executionContext.getLong(BidVolumeStatisticWriter.VOLUME_STATISTIC_KEY, 0L);
+        log.info("[NormalStatisticSaveTasklet] volume 총합 읽기: {}", totalVolumeCount);
+
+        SalesType salesType = salesTypeRepository.findByName("입찰 판매")
+                .orElseThrow(()->new IllegalArgumentException("SalesType Not Found"));
+        String statisticType = "DAY";
+
+        try {
+            // 거래량 통계 저장
+            if (!transactionAmountStatisticRepository.existsByStaticsTimeAndSalesType(statisticsTime, salesType)) {
+                transactionAmountStatisticRepository.save(TransactionAmountStatistic.builder()
+                        .transactionAmount(totalVolumeCount)
+                        .staticsTime(statisticsTime)
+                        .salesType(salesType)
+                        .statisticType(statisticType)
+                        .build());
+
+                log.info("[NormalStatisticSaveTasklet] 저장 완료. time={}, totalCnt={}", statisticsTime, totalVolumeCount);
+            }
+
+        } catch (DataIntegrityViolationException e) {
+            log.warn("[NormalStatisticSaveTasklet] 중복 통계 데이터 발생. time={}, {}", statisticsTime, e.getMessage());
+        } catch (Exception e) {
+            log.error("[NormalStatisticSaveTasklet] 통계 데이터 DB 저장 중 예상치 못한 오류 발생. time={}. {}", statisticsTime, e.getMessage(), e);
+            throw e;
+        }
+        return RepeatStatus.FINISHED;
+    }
+}

--- a/src/main/java/eureca/capstone/project/batch/component/writer/BidVolumeStatisticWriter.java
+++ b/src/main/java/eureca/capstone/project/batch/component/writer/BidVolumeStatisticWriter.java
@@ -1,0 +1,49 @@
+package eureca.capstone.project.batch.component.writer;
+
+
+import eureca.capstone.project.batch.transaction_feed.entity.DataTransactionHistory;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.StepExecution;
+import org.springframework.batch.core.annotation.BeforeStep;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.item.Chunk;
+import org.springframework.batch.item.ExecutionContext;
+import org.springframework.batch.item.ItemWriter;
+import org.springframework.stereotype.Component;
+
+@Component
+@StepScope
+@RequiredArgsConstructor
+@Slf4j
+public class BidVolumeStatisticWriter implements ItemWriter<DataTransactionHistory> {
+    public static final String VOLUME_STATISTIC_KEY = "VOLUME_STATISTIC";
+    private StepExecution stepExecution;
+    private Long totalCount;
+
+
+    @BeforeStep
+    public void saveVolumeStepExecution(StepExecution stepExecution) {
+        this.stepExecution = stepExecution;
+        ExecutionContext executionContext = stepExecution.getExecutionContext();
+
+        if (executionContext.containsKey(VOLUME_STATISTIC_KEY)) {
+            this.totalCount = executionContext.getLong(VOLUME_STATISTIC_KEY);
+        } else {
+            this.totalCount = 0L;
+            executionContext.putLong(VOLUME_STATISTIC_KEY, 0L);
+        }
+        log.info("[VolumeStatisticWriter] 초기 거래량 카운트: {}", totalCount);
+    }
+
+    @Override
+    public void write(Chunk<? extends DataTransactionHistory> chunk) throws Exception {
+        // 청크에 담긴 아이템 수만큼 누적
+        int items = chunk.getItems().size();
+        totalCount += items;
+
+        // ExecutionContext 에 저장
+        stepExecution.getExecutionContext().putLong(VOLUME_STATISTIC_KEY, totalCount);
+        log.info("[VolumeStatisticWriter] 누적 거래량 +{}건 → 총 {}건", items, totalCount);
+    }
+}

--- a/src/main/java/eureca/capstone/project/batch/component/writer/NormalStatisticWriter.java
+++ b/src/main/java/eureca/capstone/project/batch/component/writer/NormalStatisticWriter.java
@@ -21,8 +21,8 @@ import java.util.Map;
 @StepScope
 @RequiredArgsConstructor
 @Slf4j
-public class TransactionStatisticWriter implements ItemWriter<DataTransactionHistory> {
-    public static final String STEP_STATISTIC_KEY = "telecomStatistic";
+public class NormalStatisticWriter implements ItemWriter<DataTransactionHistory> {
+    public static final String NORMAL_STATISTIC_KEY = "telecomStatistic";
     private StepExecution stepExecution;
     private Map<Long, StatisticResponseDto> statistics; // (통신사 id,계산)
 
@@ -31,14 +31,14 @@ public class TransactionStatisticWriter implements ItemWriter<DataTransactionHis
         this.stepExecution = stepExecution;
         ExecutionContext executionContext = stepExecution.getExecutionContext();
 
-        this.statistics = (Map<Long, StatisticResponseDto>) executionContext.get(STEP_STATISTIC_KEY);
+        this.statistics = (Map<Long, StatisticResponseDto>) executionContext.get(NORMAL_STATISTIC_KEY);
 
         if (this.statistics == null) {
             this.statistics = new HashMap<>();
-            executionContext.put(STEP_STATISTIC_KEY, this.statistics);
-            log.info("[saveStepExecution] 기존 누적 map 없음. 새 누적 map 생성.");
+            executionContext.put(NORMAL_STATISTIC_KEY, this.statistics);
+            log.info("[NormalStatisticWriter] 기존 누적 map 없음. 새 누적 map 생성.");
         } else {
-            log.info("[saveStepExecution] 기존 누적 map 로드 (재시작)");
+            log.info("[NormalStatisticWriter] 기존 누적 map 로드 (재시작)");
         }
     }
 
@@ -48,12 +48,12 @@ public class TransactionStatisticWriter implements ItemWriter<DataTransactionHis
         for (DataTransactionHistory history : chunk.getItems()) {
             TransactionFeed feed = history.getTransactionFeed();
             if(feed == null){
-                log.warn("[write] {}번 거래내역의 TransactionFeed가 null", history.getTransactionHistoryId());
+                log.warn("[NormalStatisticWriter] {}번 거래내역의 TransactionFeed가 null", history.getTransactionHistoryId());
                 continue;
             }
             TelecomCompany telecom = feed.getTelecomCompany();
             if(telecom == null){
-                log.warn("[write] {}번 거래내역의 TelecomCompany가 null", history.getTransactionHistoryId());
+                log.warn("[NormalStatisticWriter] {}번 거래내역의 TelecomCompany가 null", history.getTransactionHistoryId());
                 continue;
             }
 
@@ -62,10 +62,10 @@ public class TransactionStatisticWriter implements ItemWriter<DataTransactionHis
             StatisticResponseDto statisticDto = statistics.getOrDefault(
                     telecomId,
                     StatisticResponseDto.builder()
-                        .totalPrice(0L)
-                        .totalDataAmount(0L)
-                        .transactionCount(0L)
-                        .build()
+                            .totalPrice(0L)
+                            .totalDataAmount(0L)
+                            .transactionCount(0L)
+                            .build()
             );
 
             Long price = history.getTransactionFinalPrice() == null ? 0L : history.getTransactionFinalPrice();
@@ -77,12 +77,12 @@ public class TransactionStatisticWriter implements ItemWriter<DataTransactionHis
                     .transactionCount(statisticDto.getTransactionCount() + 1)
                     .build();
 
-            log.info("[write] 통신사: {}, price: {}, amount: {}", telecom.getName(), history.getTransactionFinalPrice(), feed.getSalesDataAmount());
+            log.info("[NormalStatisticWriter] 통신사: {}, price: {}, amount: {}", telecom.getName(), history.getTransactionFinalPrice(), feed.getSalesDataAmount());
 
             statistics.put(telecomId, statisticDto);
         }
 
-        stepExecution.getExecutionContext().put(STEP_STATISTIC_KEY, statistics);
-        log.info("[write] 누적 집계 완료. 거래내역: {}건, 실 집계: {}개 통신사", chunk.getItems().size(), statistics.size());
+        stepExecution.getExecutionContext().put(NORMAL_STATISTIC_KEY, statistics);
+        log.info("[NormalStatisticWriter] 누적 집계 완료. 거래내역: {}건, 실 집계: {}개 통신사", chunk.getItems().size(), statistics.size());
     }
 }

--- a/src/main/java/eureca/capstone/project/batch/job/TransactionStatisticJobConfig.java
+++ b/src/main/java/eureca/capstone/project/batch/job/TransactionStatisticJobConfig.java
@@ -49,7 +49,7 @@ public class TransactionStatisticJobConfig {
     @Bean
     public Job normalStatisticJob() {
         return new JobBuilder("normalStatisticJob", jobRepository)
-                .start(normalStatisticCalculateStep()) // 시세 통계 조회 및 누적 집계
+                .start(normalStatisticCalculateStep()) // 시세 통계, 거래량 조회 및 누적 집계
                 .next(normalStatisticSaveStep())       // 통계 계산 및 저장
                 .build();
     }
@@ -58,7 +58,7 @@ public class TransactionStatisticJobConfig {
     @Bean
     public Job bidStatisticJob() {
         return new JobBuilder("bidStatisticJob", jobRepository)
-                .start(bidStatisticCalculateStep()) // 시세 통계 조회 및 누적 집계
+                .start(bidStatisticCalculateStep()) // 거래량 조회 및 누적 집계
                 .next(bidStatisticSaveStep())       // 통계 계산 및 저장
                 .build();
     }

--- a/src/main/java/eureca/capstone/project/batch/market_statistic/domain/TransactionAmountStatistic.java
+++ b/src/main/java/eureca/capstone/project/batch/market_statistic/domain/TransactionAmountStatistic.java
@@ -1,6 +1,7 @@
 package eureca.capstone.project.batch.market_statistic.domain;
 
 import eureca.capstone.project.batch.common.entity.BaseEntity;
+import eureca.capstone.project.batch.transaction_feed.entity.SalesType;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -10,7 +11,7 @@ import lombok.NoArgsConstructor;
 import java.time.LocalDateTime;
 
 @Table(name = "transaction_amount_statistics", uniqueConstraints = {
-        @UniqueConstraint(columnNames = {"statics_time"})})
+        @UniqueConstraint(columnNames = {"statics_time", "sales_type_id"})})
 @Entity
 @Getter
 @Builder
@@ -24,6 +25,13 @@ public class TransactionAmountStatistic extends BaseEntity {
 
     @Column(name = "transaction_amount")
     private long transactionAmount;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "sales_type_id")
+    private SalesType salesType;
+
+    @Column(name = "statistic_type") // HOUR/DAY
+    private String statisticType;
 
     @Column(name = "statics_time")
     private LocalDateTime staticsTime;

--- a/src/main/java/eureca/capstone/project/batch/market_statistic/repository/TransactionAmountStatisticRepository.java
+++ b/src/main/java/eureca/capstone/project/batch/market_statistic/repository/TransactionAmountStatisticRepository.java
@@ -1,10 +1,11 @@
 package eureca.capstone.project.batch.market_statistic.repository;
 
 import eureca.capstone.project.batch.market_statistic.domain.TransactionAmountStatistic;
+import eureca.capstone.project.batch.transaction_feed.entity.SalesType;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.time.LocalDateTime;
 
 public interface TransactionAmountStatisticRepository extends JpaRepository<TransactionAmountStatistic, Long> {
-    boolean existsByStaticsTime(LocalDateTime staticsTime);
+    boolean existsByStaticsTimeAndSalesType(LocalDateTime staticsTime, SalesType salesType);
 }

--- a/src/main/java/eureca/capstone/project/batch/transaction_feed/repository/SalesTypeRepository.java
+++ b/src/main/java/eureca/capstone/project/batch/transaction_feed/repository/SalesTypeRepository.java
@@ -4,5 +4,8 @@ package eureca.capstone.project.batch.transaction_feed.repository;
 import eureca.capstone.project.batch.transaction_feed.entity.SalesType;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface SalesTypeRepository extends JpaRepository<SalesType, Long> {
+    Optional<SalesType> findByName(String name);
 }


### PR DESCRIPTION
## 주요 변경사항
- 입찰판매-일반판매 거래량 통계 분리
    - Job 분리: 시세통계+일반판매 거래량 Job, 입찰판매 거래량 Job 으로 분리
        - NormalJob: 시세통계 및 일반판매 거래량 집계(chunk) - 통계 계산 및 저장(tasklet)
        - BidJob: 입찰판매 거래량 집계(chunk) - 통계 계산 및 저장(tasklet)
    - NormalJob은 매 시간 스케줄링
    - BidJob은 매일 00:05 스케줄링(NormalJob과 같은 db에 접근하므로 5분 간격 두고 진행)

관련 이슈: close #33 