### PR TITLE
fix: 그래프가 끊기지 않도록 거래량이 없을때는 이전 시간의 데이터로 시세를 내려주도록 수정(LOCF)

### DIFF
--- a/src/main/java/eureca/capstone/project/batch/component/tasklet/NormalStatisticSaveTasklet.java
+++ b/src/main/java/eureca/capstone/project/batch/component/tasklet/NormalStatisticSaveTasklet.java
@@ -85,7 +85,19 @@ public class NormalStatisticSaveTasklet implements Tasklet {
                             .transactionCount(0L)
                             .build());
 
-            Long avgPrice = dto.getTotalDataAmount() == 0 ? null : Math.round((double) dto.getTotalPrice() / dto.getTotalDataAmount() * PRICE_PER_MB);
+            Long avgPrice;
+            if (dto.getTotalDataAmount() > 0) {
+                avgPrice = Math.round((double) dto.getTotalPrice() / dto.getTotalDataAmount() * PRICE_PER_MB);
+            } else {
+                log.info("[SaveTasklet] {} 통신사 거래내역 없음. 직전 데이터 조회 시도.", telecom.getName());
+                avgPrice = marketStatisticRepository
+                        .findFirstByTelecomCompanyTelecomCompanyIdAndStaticsTimeBeforeAndAveragePriceIsNotNullOrderByStaticsTimeDesc(
+                                telecom.getTelecomCompanyId(),
+                                statisticsTime
+                        )
+                        .map(MarketStatistic::getAveragePrice) // 조회된 통계에서 averagePrice를 가져옴
+                        .orElse(null); // 만약 시스템 전체에서 한 번도 거래가 없었다면 null
+            }
 
             marketStats.add(MarketStatistic.builder()
                     .telecomCompany(telecom)

--- a/src/main/java/eureca/capstone/project/batch/market_statistic/repository/MarketStatisticRepository.java
+++ b/src/main/java/eureca/capstone/project/batch/market_statistic/repository/MarketStatisticRepository.java
@@ -6,10 +6,19 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDateTime;
+import java.util.Optional;
 import java.util.Set;
 
 public interface MarketStatisticRepository extends JpaRepository<MarketStatistic, Long> {
     @Query("select ms.telecomCompany.telecomCompanyId " +
             "from MarketStatistic ms where ms.staticsTime = :time")
     Set<Long> findTelecomIdsByStaticsTime(@Param("time") LocalDateTime time);
+
+    /**
+     * 특정 통신사의 특정 시간 이전에 기록된 가장 최근의 유효한(averagePrice is not null) 통계를 찾습니다.
+     * @param telecomCompanyId 통신사 ID
+     * @param statisticsTime 기준 시간
+     * @return 가장 최근의 MarketStatistic (Optional)
+     */
+    Optional<MarketStatistic> findFirstByTelecomCompanyTelecomCompanyIdAndStaticsTimeBeforeAndAveragePriceIsNotNullOrderByStaticsTimeDesc(Long telecomCompanyId, LocalDateTime statisticsTime);
 }


### PR DESCRIPTION
### 작업 내용
> 기존 : 이전 1시간동안의 거래량이 없을 시, null로 데이터가 내려가 그래프가 끊김
> 수정 : 이전 1시간동안의 거래량이 없을 시, 이전 시간의 데이터를 유지하여 그래프가 끊기지 않도록 수정(LOCF)